### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,13 +12,13 @@ ClosedCube_OPT3002	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ##################################################################
 
-begin KEYWORD2
-readManufacturerID KEYWORD2
-readDeviceID KEYWORD2
+begin	KEYWORD2
+readManufacturerID	KEYWORD2
+readDeviceID	KEYWORD2
 
-readResult KEYWORD2
-readHighLimit KEYWORD2
-readLowLimit KEYWORD2
+readResult	KEYWORD2
+readHighLimit	KEYWORD2
+readLowLimit	KEYWORD2
 
-readConfig KEYWORD2
-writeConfig KEYWORD2
+readConfig	KEYWORD2
+writeConfig	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords